### PR TITLE
fix: update alert window behavior based on window mode

### DIFF
--- a/src/main/alertHandler.ts
+++ b/src/main/alertHandler.ts
@@ -1,5 +1,6 @@
 import { ipcMain, app} from "electron";
 import { getMainWindow } from './main';
+import { WindowModeManager } from './windowMode';
 import path from 'path';
 import fs from 'fs';
 
@@ -59,9 +60,12 @@ export const registerAlertHandler = () => {
   ipcMain.on("trigger-warning-alerts", (event, alertOptions) => {
     const mainWindow = getMainWindow();
     if (mainWindow && alertOptions.bringToFrontEnabled) {
+      const windowModeManager = new WindowModeManager('main-window');
+      const windowMode = windowModeManager.getWindowMode();
+      const shouldStayOnTop = windowMode === 'overlay' || windowMode === 'overlayTransparent';
       mainWindow.setAlwaysOnTop(true);
       mainWindow.show();
-      mainWindow.setAlwaysOnTop(false);
+      mainWindow.setAlwaysOnTop(shouldStayOnTop);
       mainWindow.focus();
     }
     if(mainWindow && alertOptions.flashWindowEnabled) {


### PR DESCRIPTION
## Description

This PR updates the alert handling logic to respect the current window mode when managing the "always on top" behavior.

### Changes
- Introduced `WindowModeManager` to retrieve the current window mode.
- Added logic to determine if the window should remain always on top (`overlay` or `overlayTransparent` modes).
- Updated `setAlwaysOnTop` behavior to conditionally persist based on window mode instead of always resetting to `false`.

### Impact
- Ensures consistent alert behavior across different window modes.
- Prevents unintended loss of "always on top" state in overlay modes.
- Improves overall UX for alert visibility and window focus handling.