### PR TITLE
Fix for Unreachable statement

### DIFF
--- a/src/renderer/lib/linkup.ts
+++ b/src/renderer/lib/linkup.ts
@@ -102,8 +102,6 @@ export async function getAuthToken(request: LoginAttemptRequest): Promise<{
     console.log("Unable to get the token: ", error);
     throw error;
   }
-
-  return null;
 }
 
 export async function getCGMData(request: GetGeneralRequest): Promise<string|null|{error: string, message: string}> {


### PR DESCRIPTION
Remove the unreachable trailing `return null;` from `getAuthToken` in `src/renderer/lib/linkup.ts` (line 106 in the snippet).  
This is the minimal and best fix because it preserves current runtime behavior exactly: today that line is never executed, so deleting it does not change functionality. No imports, new methods, or type changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._