### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/renderer/pages/settings/general.tsx
+++ b/src/renderer/pages/settings/general.tsx
@@ -1,5 +1,4 @@
 import { ThemeType, useTheme } from "@/components/theme-provider"
-import { Button } from "@/components/ui/button"
 import { ToggleSwitch } from "@/components/ui/toggle-switch"
 import SettingsLayout from "@/layouts/settings-layout"
 import { cn } from "@/lib/utils"


### PR DESCRIPTION
To fix an unused import without changing behavior, remove the unused symbol from the import section.

Best fix here: in `src/renderer/pages/settings/general.tsx`, delete the `Button` import line:
- Remove `import { Button } from "@/components/ui/button"` (line 2 in the snippet).
- No other code changes are required.
- No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._