### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/renderer/pages/settings/alert.tsx
+++ b/src/renderer/pages/settings/alert.tsx
@@ -3,11 +3,7 @@ import { ToggleSwitch } from '@/components/ui/toggle-switch';
 import SettingsLayout from '@/layouts/settings-layout';
 import { useAlertStore } from '@/stores/alertStore';
 import { useTranslation } from 'react-i18next';
-import {
-  uploadCustomAlertSoundFile,
-  sendRefreshPrimaryWindow,
-  sendRefreshAllWindows,
-} from '@/lib/utils';
+import { uploadCustomAlertSoundFile, sendRefreshPrimaryWindow } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 


### PR DESCRIPTION
To fix this without changing functionality, remove `sendRefreshAllWindows` from the grouped import from `@/lib/utils` in `src/renderer/pages/settings/alert.tsx`.

Best single fix:
- Edit the import block at lines 6–10.
- Keep `uploadCustomAlertSoundFile` and `sendRefreshPrimaryWindow`.
- Delete only `sendRefreshAllWindows`.

No new methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._