### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/renderer/pages/settings/general.tsx
+++ b/src/renderer/pages/settings/general.tsx
@@ -3,7 +3,6 @@ import { Button } from "@/components/ui/button"
 import { ToggleSwitch } from "@/components/ui/toggle-switch"
 import SettingsLayout from "@/layouts/settings-layout"
 import { cn } from "@/lib/utils"
-import { useNavigate } from "react-router-dom"
 import {
   Select,
   SelectContent,
@@ -18,7 +17,6 @@ import { setRedirectTo, sendRefreshPrimaryWindow, setWindowMode, getLocalStorage
 import { useEffect, useState, useCallback  } from 'react';
 
 export default function SettingsGeneralPage() {
-  const navigate = useNavigate()
   const { i18n, t } = useTranslation()
   const theme = localStorage.getItem('vite-ui-theme')
   const language = useAuthStore((state) => state.language)


### PR DESCRIPTION
Remove the unused `navigate` variable and its corresponding `useNavigate` import from `src/renderer/pages/settings/general.tsx`.

Best fix without changing functionality:
- Delete `import { useNavigate } from "react-router-dom"` (line 6).
- Delete `const navigate = useNavigate()` inside `SettingsGeneralPage` (line 21).
- No behavior changes occur, since `navigate` is not used.

No new methods, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._