### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/renderer/layouts/settings-layout.tsx
+++ b/src/renderer/layouts/settings-layout.tsx
@@ -2,7 +2,6 @@ import { Button } from '@/components/ui/button';
 import { BaseLayout } from '@/layouts/base-layout';
 import { cn } from '@/lib/utils';
 import {
-  ArrowLeftIcon,
   MixerVerticalIcon,
   PersonIcon,
   BellIcon,


### PR DESCRIPTION
Remove `ArrowLeftIcon` from the `@radix-ui/react-icons` import list in `src/renderer/layouts/settings-layout.tsx`.

- General fix: for unused-import findings, remove the unused symbol from the import statement (or reintroduce real usage if needed).
- Best fix here without changing behavior: edit only the icon import block and delete `ArrowLeftIcon`.
- File/region: `src/renderer/layouts/settings-layout.tsx`, lines 4–9.
- No additional methods, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._