### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/renderer/layouts/settings-layout.tsx
+++ b/src/renderer/layouts/settings-layout.tsx
@@ -44,7 +44,6 @@ function SidebarButton({
 }
 
 export default function SettingsLayout({ children }: Props) {
-  const navigate = useNavigate();
   const { t } = useTranslation();
 
   return (


### PR DESCRIPTION
To fix this without changing functionality, remove the unused local variable in `SettingsLayout`:

- **File:** `src/renderer/layouts/settings-layout.tsx`
- **Change region:** inside `export default function SettingsLayout({ children }: Props) { ... }`
- **Specific edit:** delete `const navigate = useNavigate();`

No new imports, methods, or definitions are needed. `useNavigate` is still required by `SidebarButton`, so do **not** remove it from the import list.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._