### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/renderer/pages/dashboard.tsx
+++ b/src/renderer/pages/dashboard.tsx
@@ -3,10 +3,7 @@ import { BaseLayout } from '@/layouts/base-layout';
 import { useAuthStore } from '@/stores/auth';
 import { getCGMData } from '@/lib/linkup';
 import { TrendArrow } from '@/components/ui/trend-arrow';
-import {
-  EnterFullScreenIcon,
-  GearIcon,
-} from '@radix-ui/react-icons';
+import { GearIcon } from '@radix-ui/react-icons';
 import { useNavigate } from 'react-router-dom';
 import { LoadingScreen } from '@/components/ui/loading';
 import { useClearSession } from '@/hooks/session';


### PR DESCRIPTION
The correct fix is to remove only the unused named import while preserving the rest of the import statement and behavior.

- **General fix**: delete unused imports that are not referenced anywhere in the file.
- **Best fix here**: in `src/renderer/pages/dashboard.tsx`, update the `@radix-ui/react-icons` import to keep `GearIcon` only.
- **Scope**: only lines around the import block near lines 6–9.
- **No additional methods/imports/definitions** are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._