### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/renderer/pages/settings/general.tsx
+++ b/src/renderer/pages/settings/general.tsx
@@ -2,7 +2,6 @@ import { ThemeType, useTheme } from "@/components/theme-provider"
 import { Button } from "@/components/ui/button"
 import { ToggleSwitch } from "@/components/ui/toggle-switch"
 import SettingsLayout from "@/layouts/settings-layout"
-import { cn } from "@/lib/utils"
 import { useNavigate } from "react-router-dom"
 import {
   Select,


### PR DESCRIPTION
To fix an unused import, remove the specific import binding that is not referenced anywhere in the file.

Best fix for this snippet: delete `import { cn } from "@/lib/utils"` from `src/renderer/pages/settings/general.tsx` (line 5 in the provided snippet). This does not change runtime behavior and keeps functionality intact while satisfying the lint/static analysis rule.

No new methods, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._