### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/renderer/pages/dashboard.tsx
+++ b/src/renderer/pages/dashboard.tsx
@@ -35,7 +35,7 @@ export default function DashboardPage() {
   const accountId = useAuthStore((state) => state.accountId);
   const [graphData, setGraphData] = useState<any>({});
   const [isReady, setIsReady] = useState(false);
-  const [trayVisible, setTrayVisible] = useState<boolean>(true);
+  const [trayVisible] = useState<boolean>(true);
 
   const updateTrayManually = () => {
     if (graphData?.glucoseMeasurement?.ValueInMgPerDl !== undefined &&


### PR DESCRIPTION
To fix an unused React state setter without changing functionality, keep only the state value if that value is used, and omit the setter from the `useState` tuple destructuring.

In `src/renderer/pages/dashboard.tsx`, update line 38 so the component only captures `trayVisible` and not `setTrayVisible`. This resolves the CodeQL warning while preserving current behavior. No new methods, imports, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._