### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/renderer/pages/dashboard.tsx
+++ b/src/renderer/pages/dashboard.tsx
@@ -35,7 +35,6 @@ export default function DashboardPage() {
   const accountId = useAuthStore((state) => state.accountId);
   const [graphData, setGraphData] = useState<any>({});
   const [isReady, setIsReady] = useState(false);
-  const [trayVisible, setTrayVisible] = useState<boolean>(true);
 
   const updateTrayManually = () => {
     if (graphData?.glucoseMeasurement?.ValueInMgPerDl !== undefined &&


### PR DESCRIPTION
To fix this cleanly without changing behavior, remove the unused React state variable declaration for `trayVisible` from `DashboardPage`.

Best single fix:
- In `src/renderer/pages/dashboard.tsx`, delete line 38:
  - `const [trayVisible, setTrayVisible] = useState<boolean>(true);`
- No imports need to change because `useState` is still used by other state variables (`graphData`, `isReady`).

This preserves current functionality while resolving the unused-variable warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._