### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/renderer/pages/dashboard.tsx
+++ b/src/renderer/pages/dashboard.tsx
@@ -28,7 +28,6 @@ const LOW = 70;
 const HIGH = 240;
 
 export default function DashboardPage() {
-  const { clearSession } = useClearSession();
   const navigate = useNavigate();
   const token = useAuthStore((state) => state.token);
   const country = useAuthStore((state) => state.country);


### PR DESCRIPTION
To fix this without changing behavior, remove the unused `clearSession` variable binding on line 31. Because the value is not used, deleting the destructure avoids the warning and preserves runtime functionality.

Best fix in this snippet:
- In `src/renderer/pages/dashboard.tsx`, remove:
  - `const { clearSession } = useClearSession();`
- Keep all other logic unchanged.

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._