### PR TITLE
Potential fix for code scanning alert no. 344: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 9 * * 4'
 
+permissions:
+  contents: read
+
 jobs:
   analyse:
     name: Analyse


### PR DESCRIPTION
Potential fix for [https://github.com/Crazy-Marvin/LibreLinkUpDesktop/security/code-scanning/344](https://github.com/Crazy-Marvin/LibreLinkUpDesktop/security/code-scanning/344)

Add an explicit `permissions` block to `.github/workflows/codeql-analysis.yml` at workflow root so it applies to all jobs (including `analyse`) unless overridden.

Best minimal fix (without changing functional behavior): add:

- `permissions:`
  - `contents: read`

Place it right after the trigger section (`on:` block) and before `jobs:`. This satisfies the CodeQL requirement and documents least-privilege intent while keeping current workflow logic unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
